### PR TITLE
add feature/bot-movements

### DIFF
--- a/lib/controllers/minecraft-bots.js
+++ b/lib/controllers/minecraft-bots.js
@@ -1,3 +1,78 @@
 const { Router } = require('express');
+const mineflayer = require('mineflayer');
 
 module.exports = Router()
+
+  .get('/', (req, res) => {
+
+    let target = null;
+
+    const bot = mineflayer.createBot({
+      host: '3.139.57.213',
+      port: '25565',
+      username: 'DoniBot',
+      password: ''
+    })
+
+    bot.on('chat', (username, message) => {
+      if (username === bot.username) return target = bot.players[username].entity
+      let entity
+      switch (message) {
+
+        // Bot movement which are toggles
+
+        case 'forward':
+          bot.setControlState('forward', true)
+          break
+        case 'forward-stop':
+          bot.setControlState('forward', false)
+          break
+
+        case 'back':
+          bot.setControlState('back', true)
+          break
+        case 'back-stop':
+          bot.setControlState('back', false)
+          break
+
+        case 'left':
+          bot.setControlState('left', true)
+          break
+        case 'left-stop':
+          bot.setControlState('left', false)
+          break
+
+        case 'right':
+          bot.setControlState('right', true)
+          break
+        case 'right-stop':
+          bot.setControlState('right', false)
+          break
+
+        case 'jump-on':
+          bot.setControlState('jump', true)
+          break
+        case 'jump-off':
+          bot.setControlState('jump', false)
+          break
+
+        // Bot movement single
+
+        case 'jump':
+          bot.setControlState('jump', true)
+          bot.setControlState('jump', false)
+          break
+        case 'attack':
+          entity = bot.nearestEntity()
+          if (entity) {
+            bot.attack(entity, true)
+          } else {
+            bot.chat('no nearby entities')
+          }
+          break
+      }
+    })
+
+
+
+  })  


### PR DESCRIPTION
### Bot movements using commands in chat for now

- forward, forward-stop: makes it go straight ahead in head direction
- back, back-stop: is same as above but backwards
- left, left-stop: left variant
- right, right-stop: right variant
- jump: single jump
- jump-on, jump-off: toggle on or off jumping
- attack: attack in bots head direction once
